### PR TITLE
Add Flexam website pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flexam | Automated Slicing Software</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="logo"><strong>Flexam</strong></div>
+    <nav>
+      <a href="index.html">Software</a>
+      <a href="#applications">Applications</a>
+      <a href="#partners">Partners</a>
+      <a href="team.html">Team</a>
+      <a class="cta" href="#demo">Book a Demo</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="software" class="hero">
+      <h1>Automated slicing software.<br>Designed for robotic and multi-axis 3D printing.</h1>
+      <p>Fully automated slicing tailored to your machines and workflows. Use the most advanced machine learning and slicing technology to stay ahead of the competition.</p>
+      <div class="actions">
+        <a class="cta" href="#demo">Book a Demo</a>
+        <a class="link" href="#how-it-works">See How It Works</a>
+      </div>
+    </section>
+
+    <section class="why">
+      <h2>Why Flexam</h2>
+      <p>Take control of multi-axis printing. No manual slicing. Best results in minutes.</p>
+      <ul>
+        <li>Automatically segments and analyzes complex geometry</li>
+        <li>Assigns optimal slicing strategies for each region</li>
+        <li>Generates hybrid G-code with smooth, transition-aware paths</li>
+        <li>Fully compatible with robotic arms and industrial 3D printers</li>
+      </ul>
+      <p class="highlight">Print faster. Waste less.</p>
+      <a class="link" href="#product">Learn More About the Product</a>
+    </section>
+
+    <section id="how-it-works" class="how">
+      <h2>How It Works</h2>
+      <p>Upload any 3D model. Flexam takes care of the rest. No manual slicing. No CAD prep. No guesswork.</p>
+      <ol>
+        <li>Upload your model — STL, STEP, OBJ</li>
+        <li>Automatic segmentation &amp; analysis</li>
+        <li>Optimal slicing strategy per region</li>
+        <li>Hybrid G-code generation</li>
+        <li>Export &amp; print on your system</li>
+      </ol>
+      <p class="highlight">From complex geometry to clean toolpaths in minutes.</p>
+      <div class="actions">
+        <a class="link" href="#segmentation">Learn About Segmentation</a>
+        <a class="link" href="#demo-video">Watch a Demo</a>
+      </div>
+    </section>
+
+    <section id="demo" class="demo">
+      <h2>Book a Demo</h2>
+      <p>See how Flexam fits your exact workflow—no prep, no scripting, no surprises. We will tailor the session to your machine, part types, and challenges.</p>
+      <p><strong>Prefer to test it directly?</strong> Upload your model—we’ll slice it and send back the G-code.</p>
+      <a class="cta" href="mailto:hello@flexam.pro">Book a Demo</a>
+    </section>
+
+    <section id="team" class="team">
+      <h2>Team</h2>
+      <p>Reimagining how complex 3D printing gets done.</p>
+      <p>Since 2021, we’re building slicing software for robotic and multi-axis 3D printing. Based in Vienna and backed by FFG, we work to bring industrial 3D printing into a more advanced era of manufacturing.</p>
+      <div class="founders">
+        <div class="founder">
+          <h3>Mike Ivanov</h3>
+          <p>Co-founder & CTO — PhD in Robotics.</p>
+        </div>
+        <div class="founder">
+          <h3>Artem Gordeev</h3>
+          <p>Co-founder & CEO — MBA in Entrepreneurship & Innovation.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-top">
+      <div>
+        <p><strong>Flexam GmbH</strong><br>Slicing software for robotic and multi-axis 3D printing<br>Vienna, Austria</p>
+        <p><a href="mailto:hello@flexam.pro">hello@flexam.pro</a></p>
+      </div>
+      <nav class="footer-links">
+        <a href="index.html">Software</a>
+        <a href="#demo">Book a Demo</a>
+        <a href="team.html">Team</a>
+        <a href="#legal">Legal Notice</a>
+        <a href="#privacy">Privacy Policy</a>
+      </nav>
+    </div>
+    <p class="copyright">© 2025 Flexam GmbH. All rights reserved. Made in Austria.</p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,120 @@
+:root {
+  --primary: #000000;
+  --accent: #0070F3;
+  --background: #FFFFFF;
+  --secondary-text: #6E6E6E;
+  --border: #E5E5E5;
+  font-family: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--background);
+  color: var(--primary);
+  font-size: 16px;
+  line-height: 1.6;
+  font-family: 'Inter', sans-serif;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+nav a {
+  margin: 0 1rem;
+  text-decoration: none;
+  color: var(--primary);
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+nav a:hover {
+  color: var(--accent);
+}
+
+.cta {
+  background-color: var(--accent);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.cta:hover {
+  background-color: #005fcc;
+}
+
+section {
+  padding: 4rem 2rem;
+  max-width: 900px;
+  margin: auto;
+}
+
+.hero {
+  text-align: left;
+}
+
+.actions {
+  margin-top: 1.5rem;
+}
+
+.actions .link {
+  margin-left: 1rem;
+  text-decoration: underline;
+  color: var(--accent);
+}
+
+h1, h2, h3 {
+  margin-top: 0;
+}
+
+.highlight {
+  font-weight: 600;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem;
+  font-size: 14px;
+  color: var(--secondary-text);
+  border-top: 1px solid var(--border);
+}
+
+.footer-top {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.footer-links a {
+  margin: 0 0.5rem;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  text-decoration: underline;
+}
+
+.team-page .founders {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.founder h3 {
+  margin-bottom: 0.5rem;
+}

--- a/team.html
+++ b/team.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flexam | Team</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="logo"><strong>Flexam</strong></div>
+    <nav>
+      <a href="index.html">Software</a>
+      <a href="#applications">Applications</a>
+      <a href="#partners">Partners</a>
+      <a href="team.html">Team</a>
+      <a class="cta" href="index.html#demo">Book a Demo</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="team-page">
+      <h1>Reimagining how complex 3D printing gets done.</h1>
+      <p>Since 2021, we’re building slicing software for robotic and multi-axis 3D printing. Based in Vienna and backed by FFG, we work to bring industrial 3D printing into a more advanced era of manufacturing.</p>
+      <h2>Founders</h2>
+      <div class="founders">
+        <div class="founder">
+          <h3>Mike Ivanov</h3>
+          <p>Co-founder & CTO</p>
+          <p>PhD in Robotics.</p>
+        </div>
+        <div class="founder">
+          <h3>Artem Gordeev</h3>
+          <p>Co-founder & CEO</p>
+          <p>MBA in Entrepreneurship & Innovation.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-top">
+      <div>
+        <p><strong>Flexam GmbH</strong><br>Slicing software for robotic and multi-axis 3D printing<br>Vienna, Austria</p>
+        <p><a href="mailto:hello@flexam.pro">hello@flexam.pro</a></p>
+      </div>
+      <nav class="footer-links">
+        <a href="index.html">Software</a>
+        <a href="index.html#demo">Book a Demo</a>
+        <a href="team.html">Team</a>
+        <a href="#legal">Legal Notice</a>
+        <a href="#privacy">Privacy Policy</a>
+      </nav>
+    </div>
+    <p class="copyright">© 2025 Flexam GmbH. All rights reserved. Made in Austria.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create landing page with copy, layout, and links
- add team page
- implement shared stylesheets for color palette, fonts, and layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688b21091a448331ba094a7e825f431b